### PR TITLE
Lower Android min sdk level

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/mirego/viewmodel/pilot/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/mirego/viewmodel/pilot/KotlinAndroid.kt
@@ -17,7 +17,7 @@ internal fun Project.configureKotlinAndroid(
         compileSdk = 34
 
         defaultConfig {
-            minSdk = 26
+            minSdk = 21
         }
 
         compileOptions {


### PR DESCRIPTION
Since we want to use this library in some project that still has minSdk = 21, we should lower the minSdk version