### PR TITLE
Navigation: Add a way to “pop” the root on iOS

### DIFF
--- a/navigation/ios/Navigation.swift
+++ b/navigation/ios/Navigation.swift
@@ -6,14 +6,16 @@ public extension View {
         navigationManager: PilotNavigationManager<Route, Action>,
         @ViewBuilder buildView: @escaping (ScreenData) -> ScreenView,
         buildNavigation: @escaping ([Route], Route) -> PilotNavigationType<ScreenData, NavModifier>?,
-        handleAction: ((Action) -> Void)? = nil
+        handleAction: ((Action) -> Void)? = nil,
+        handlePopRoot: (() -> Void)? = nil
     ) -> some View {
         modifier(
             NavigationModifier<ScreenData, Route, Action, ScreenView, NavModifier>(
                 buildView: buildView,
                 buildNavigation: buildNavigation,
                 handleAction: handleAction,
-                navigationManager: navigationManager
+                navigationManager: navigationManager,
+                handlePopRoot: handlePopRoot
             )
         )
     }
@@ -28,7 +30,8 @@ private struct NavigationModifier<ScreenData, Route: PilotNavigationRoute, Actio
         buildView: @escaping (ScreenData) -> ScreenView,
         buildNavigation: @escaping ([Route], Route) -> PilotNavigationType<ScreenData, NavModifier>?,
         handleAction: ((Action) -> Void)? = nil,
-        navigationManager: PilotNavigationManager<Route, Action>? = nil
+        navigationManager: PilotNavigationManager<Route, Action>? = nil,
+        handlePopRoot: (() -> Void)?
     ) {
         self.buildView = buildView
         let rootNavigationState = NavigationState<ScreenData, Route, Action, NavModifier>(
@@ -36,7 +39,8 @@ private struct NavigationModifier<ScreenData, Route: PilotNavigationRoute, Actio
             route: nil,
             buildNavigation: buildNavigation,
             handleAction: handleAction,
-            navigationManager: navigationManager
+            navigationManager: navigationManager,
+            handlePopRoot: handlePopRoot
         )
         _rootState = StateObject(wrappedValue: rootNavigationState)
     }

--- a/navigation/ios/NavigationState.swift
+++ b/navigation/ios/NavigationState.swift
@@ -23,6 +23,7 @@ class NavigationState<
     private let buildNavigation: (([Route], Route) -> PilotNavigationType<ScreenData, NavModifier>?)?
     private let navigationManager: PilotNavigationManager<Route, Action>?
     private let actionListener: ActionListener<Route, Action>
+    private let handlePopRoot: (() -> Void)?
     private var lastNavigationDate: Foundation.Date?
 
     init(
@@ -30,12 +31,14 @@ class NavigationState<
         route: Route?,
         buildNavigation: (([Route], Route) -> PilotNavigationType<ScreenData, NavModifier>?)? = nil,
         handleAction: ((Action) -> Void)? = nil,
-        navigationManager: PilotNavigationManager<Route, Action>? = nil
+        navigationManager: PilotNavigationManager<Route, Action>? = nil,
+        handlePopRoot: (() -> Void)? = nil
     ) {
         self.navigation = navigation
         self.route = route
         self.buildNavigation = buildNavigation
         self.navigationManager = navigationManager
+        self.handlePopRoot = handlePopRoot
         actionListener = ActionListener(navigationManager: navigationManager, handleAction: handleAction)
 
         super.init()
@@ -86,6 +89,8 @@ class NavigationState<
                 } else {
                     topPresenter.child = nil
                 }
+            } else {
+                self?.handlePopRoot?()
             }
         }
     }


### PR DESCRIPTION
This functionality becomes necessary when the Pilot navigation stack is not implemented at the app's root level but is instead utilized within a specific app section. Given that the navigation stack might be integrated within a navigation controller or displayed in a modally, the responsibility to close the stack must be transferred to the caller.

To address this requirement, an optional closure named "popRoot" has been introduced at the navigation's entry point, enabling a flexible approach to close the stack.