### PR TITLE
Android navigation: add a way to pop the root

### DIFF
--- a/navigation/common/api/navigation.api
+++ b/navigation/common/api/navigation.api
@@ -68,6 +68,7 @@ public final class com/mirego/pilot/navigation/compose/PilotBackHandlerKt {
 public class com/mirego/pilot/navigation/compose/PilotNavControllerNavigationListener : com/mirego/pilot/navigation/PilotNavigationListener {
 	public static final field $stable I
 	public fun <init> (Landroidx/navigation/NavController;)V
+	public fun onRootPop ()V
 	public fun pop ()V
 	public fun popTo (Lcom/mirego/pilot/navigation/PilotNavigationRoute;Z)V
 	public fun push (Lcom/mirego/pilot/navigation/PilotNavigationRoute;)Z

--- a/navigation/common/src/androidMain/kotlin/com/mirego/pilot/navigation/compose/PilotNavControllerNavigationListener.kt
+++ b/navigation/common/src/androidMain/kotlin/com/mirego/pilot/navigation/compose/PilotNavControllerNavigationListener.kt
@@ -16,6 +16,8 @@ public open class PilotNavControllerNavigationListener<ROUTE : PilotNavigationRo
     override fun pop() {
         if (navController.previousBackStackEntry != null) {
             navController.popBackStack()
+        } else {
+            onRootPop()
         }
     }
 
@@ -24,5 +26,8 @@ public open class PilotNavControllerNavigationListener<ROUTE : PilotNavigationRo
             route = route.navRoute,
             inclusive = inclusive,
         )
+    }
+
+    public open fun onRootPop() {
     }
 }


### PR DESCRIPTION
This functionality becomes necessary when the Pilot navigation stack is not implemented at the app's root level but is instead utilized within a specific app section. Given that the navigation stack might be integrated within a navigation controller or displayed in a modally, the responsibility to close the stack must be transferred to the caller.

To address this requirement, an optional closure named "onRootPop" has been introduced as an override for `PilotNavControllerNavigationListener`, enabling a flexible approach to close the stack.