### PR TITLE
Fix issue for fullscreen not animated navigation on iOS 18

### DIFF
--- a/navigation/ios/FullScreenNotAnimatedPresenter.swift
+++ b/navigation/ios/FullScreenNotAnimatedPresenter.swift
@@ -56,7 +56,7 @@ struct FullScreenNotAnimatedPresenter<Content: View>: UIViewRepresentable {
             controller.view.backgroundColor = .clear
             controller.modalPresentationStyle = .overFullScreen
 
-            guard let presenting = view.owningController else {
+            guard let presenting = view.nextViewController else {
                 resetItemBinding()
                 return
             }
@@ -88,14 +88,12 @@ struct FullScreenNotAnimatedPresenter<Content: View>: UIViewRepresentable {
     }
 }
 
-extension UIView {
-    var owningController: UIViewController? {
-        if let responder = next as? UIViewController {
-            return responder
-        } else if let responder = next as? UIView {
-            return responder.owningController
+extension UIResponder {
+    var nextViewController: UIViewController? {
+        if let viewControllerResponder = self as? UIViewController {
+            viewControllerResponder
         } else {
-            return nil
+            next?.nextViewController
         }
     }
 }


### PR DESCRIPTION
Depuis iOS 18, la chaîne de _responder_ a changé et ça brise la navigation pour `.fullScreenNotAnimated(...)`.

## Le problème
Pour iOS 17 ou moins, la chaîne est:

```
(lldb) po next
TtGC7SwiftUI16PlatformViewHostGVS_P10$10f99d05832PlatformViewRepresentableAdaptorGV5Pilot30FullScreenNotAnimatedPresenterVS_7AnyView__: 0x7fa6ab32dea0

(lldb) po next?.next
TtGC7SwiftUI14_UIHostingViewV11FoodJourney6FJView: 0x7fa6ac096800

(lldb) po next?.next?.next
FoodJourney.FJViewController: 0x7fa6ac089c00 // <- le view controller attendu
```

Depuis iOS 18, la chaîne a un objet supplémentaire qui est ni une `UIView`, ni un `UIViewController`. Il hérite quand même de `UIResponder`. C'est un type interne, non-accessible.

```
(lldb) po next
TtGC7SwiftUI16PlatformViewHostGVS_P10$117d945d432PlatformViewRepresentableAdaptorGV5Pilot30FullScreenNotAnimatedPresenterVS_7AnyView__: 0x7fe0a1317f70

(lldb) po next?.next
TtGC7SwiftUI14_UIHostingViewV11FoodJourney6FJView: 0x7fe101987000

(lldb) po next?.next?.next
SwiftUI.UIKitKeyPressResponder: 0x600001d9bf00 // <- objet autre que UIView/UIViewController

(lldb) po next?.next?.next?.next
FoodJourney.FJViewController: 0x7fe11120d200 // <- le view controller attendu
```

## Le fix
Au lieu de juste vérifier le prochain, on traverse la chaîne jusqu'à ce qu'on trouve un _view controller_. Passer par une `UIView` est inutile dans ce cas-ci. 

La chaîne a une fin:
```
... -> UIWindow -> UIWindowScene -> UIApplication -> <target>.AppDelegate -> nil
```

Un _view controller_ sera toujours dans cette chaîne pour une `UIView` affichée. Si la vue n'est pas attachée, `nil` sera retourné.
