### PR TITLE
[Components] Fixes and extensibility changes in for Coil android components

### DIFF
--- a/components/android/coil/api/components-coil.api
+++ b/components/android/coil/api/components-coil.api
@@ -1,8 +1,8 @@
 public final class com/mirego/pilot/components/ui/coil/PilotRemoteImageKt {
-	public static final fun PilotRemoteImage-_kETKwk (Lcom/mirego/pilot/components/PilotRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLandroidx/compose/runtime/Composer;II)V
+	public static final fun PilotRemoteImage-nWU5RSE (Lcom/mirego/pilot/components/PilotRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/pilot/components/ui/coil/PilotResizableRemoteImageKt {
-	public static final fun PilotResizableRemoteImage-_kETKwk (Lcom/mirego/pilot/components/PilotResizableRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLandroidx/compose/runtime/Composer;II)V
+	public static final fun PilotResizableRemoteImage-nWU5RSE (Lcom/mirego/pilot/components/PilotResizableRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/components/android/coil/src/main/kotlin/com/mirego/pilot/components/ui/coil/PilotRemoteImage.kt
+++ b/components/android/coil/src/main/kotlin/com/mirego/pilot/components/ui/coil/PilotRemoteImage.kt
@@ -28,11 +28,13 @@ public fun PilotRemoteImage(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     allowHardware: Boolean = true,
+    asyncImageBuilder: ImageRequest.Builder.() -> Unit = {},
 ) {
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(pilotRemoteImage.url)
             .allowHardware(allowHardware)
+            .apply(asyncImageBuilder)
             .build(),
         contentDescription = pilotRemoteImage.contentDescription,
         modifier = modifier,
@@ -52,8 +54,8 @@ public fun PilotRemoteImage(
 internal fun transformOf(placeholder: Painter): (AsyncImagePainter.State) -> AsyncImagePainter.State =
     { state ->
         when (state) {
-            is AsyncImagePainter.State.Loading -> state.copy(painter = placeholder)
-            is AsyncImagePainter.State.Error -> state.copy(painter = placeholder)
+            is AsyncImagePainter.State.Loading -> if (state.painter == null) state.copy(painter = placeholder) else state
+            is AsyncImagePainter.State.Error -> if (state.painter == null) state.copy(painter = placeholder) else state
             else -> state
         }
     }

--- a/components/android/coil/src/main/kotlin/com/mirego/pilot/components/ui/coil/PilotResizableRemoteImage.kt
+++ b/components/android/coil/src/main/kotlin/com/mirego/pilot/components/ui/coil/PilotResizableRemoteImage.kt
@@ -30,6 +30,7 @@ public fun PilotResizableRemoteImage(
     colorFilter: ColorFilter? = null,
     filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
     allowHardware: Boolean = true,
+    asyncImageBuilder: ImageRequest.Builder.() -> Unit = {},
 ) {
     BoxWithConstraints(modifier) {
         with(LocalDensity.current) {
@@ -43,9 +44,10 @@ public fun PilotResizableRemoteImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(url)
                     .allowHardware(allowHardware)
+                    .apply(asyncImageBuilder)
                     .build(),
                 contentDescription = pilotRemoteImage.contentDescription,
-                modifier = modifier,
+                modifier = Modifier.matchParentSize(),
                 transform = pilotRemoteImage.placeholder
                     ?.let { transformOf(pilotImageResourcePainter(it)) }
                     ?: AsyncImagePainter.DefaultTransform,


### PR DESCRIPTION
Various changes and fixes to Pilot coil components in android

- Allow image builder to be customized externally in `PilotResizableRemoteImage` & `PilotRemoteImage`
- Make sure `AsyncImagePainter` transform does not override image with placeholder when loading from cache. 
- Fix an issue in `PilotResizableRemoteImage` where the provided modifier was applied twice (once on the BoxWithContraints and once on the `AsyncImage`). Instead of doing that we now match parent size on the `AsyncImage` modifier.

Note: Binary incompatible change but source compatible