### PR TITLE
Add new Coil3 module + update several dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Each [release](https://github.com/mirego/viewmodel-pilot/releases) outlines what
   <td><img alt="kotlin 2.0.0" src="https://img.shields.io/badge/kotlin-2.0.0-blue.svg?logo=kotlin" /></td><td><img alt="0.3.0" src="https://img.shields.io/maven-metadata/v?label=mirego-maven&versionPrefix=0.3.0&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Fpilot%2Fviewmodel%2Fmaven-metadata.xml"></td>
  </tr>
  <tr>
-  <td><img alt="kotlin 2.2.0" src="https://img.shields.io/badge/kotlin-2.2.0-blue.svg?logo=kotlin" /></td><td><img alt="0.3.8" src="https://img.shields.io/maven-metadata/v?label=mirego-maven&versionPrefix=0.3.8&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Fpilot%2Fviewmodel%2Fmaven-metadata.xml"></td>
+  <td><img alt="kotlin 2.2.0" src="https://img.shields.io/badge/kotlin-2.2.0-blue.svg?logo=kotlin" /></td><td><img alt="0.4.0" src="https://img.shields.io/maven-metadata/v?label=mirego-maven&versionPrefix=0.4.0&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Fpilot%2Fviewmodel%2Fmaven-metadata.xml"></td>
  </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>Pilot is a library that allows you to share viewmodels, navigation and components on android and iOS</p>
-  <a href="http://kotlinlang.org"><img alt="kotlin 2.0.0" src="https://img.shields.io/badge/kotlin-2.0.0-blue.svg?logo=kotlin" /></a>
+  <a href="http://kotlinlang.org"><img alt="kotlin 2.2.0" src="https://img.shields.io/badge/kotlin-2.2.0-blue.svg?logo=kotlin" /></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img alt="BSD-3 Clause" src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" /></a>
   <a href="https://github.com/mirego/viewmodel-pilot/tags"><img alt="Latest"  src="https://img.shields.io/github/tag/mirego/viewmodel-pilot.svg?label=latest"></a>
   <a href="https://github.com/mirego/viewmodel-pilot/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/mirego/viewmodel-pilot/actions/workflows/ci.yml/badge.svg" /></a>
@@ -22,6 +22,9 @@ Each [release](https://github.com/mirego/viewmodel-pilot/releases) outlines what
  </tr>
  <tr>
   <td><img alt="kotlin 2.0.0" src="https://img.shields.io/badge/kotlin-2.0.0-blue.svg?logo=kotlin" /></td><td><img alt="0.3.0" src="https://img.shields.io/maven-metadata/v?label=mirego-maven&versionPrefix=0.3.0&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Fpilot%2Fviewmodel%2Fmaven-metadata.xml"></td>
+ </tr>
+ <tr>
+  <td><img alt="kotlin 2.2.0" src="https://img.shields.io/badge/kotlin-2.2.0-blue.svg?logo=kotlin" /></td><td><img alt="0.3.8" src="https://img.shields.io/maven-metadata/v?label=mirego-maven&versionPrefix=0.3.8&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Fpilot%2Fviewmodel%2Fmaven-metadata.xml"></td>
  </tr>
 </table>
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -12,8 +13,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/components/android/coil3/api/components-coil3.api
+++ b/components/android/coil3/api/components-coil3.api
@@ -1,0 +1,8 @@
+public final class com/mirego/pilot/components/ui/coil3/PilotRemoteImageKt {
+	public static final fun PilotRemoteImage-nWU5RSE (Lcom/mirego/pilot/components/PilotRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/pilot/components/ui/coil3/PilotResizableRemoteImageKt {
+	public static final fun PilotResizableRemoteImage-nWU5RSE (Lcom/mirego/pilot/components/PilotResizableRemoteImage;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/components/android/coil3/build.gradle.kts
+++ b/components/android/coil3/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
     implementation(libs.coil3.compose)
+    implementation(libs.coil3.network.okhttp)
 }
 
 afterEvaluate {

--- a/components/android/coil3/build.gradle.kts
+++ b/components/android/coil3/build.gradle.kts
@@ -1,0 +1,35 @@
+@file:Suppress("DSL_SCOPE_VIOLATION")
+
+plugins {
+    id("buildlogic.android.library")
+    alias(libs.plugins.compose.compiler)
+}
+
+group = "com.mirego.pilot"
+
+android {
+    namespace = "com.mirego.pilot.components.coil3"
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(projects.components)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.coil3.compose)
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                artifactId = "components-coil3"
+            }
+        }
+    }
+}

--- a/components/android/coil3/src/main/kotlin/com/mirego/pilot/components/ui/coil3/PilotRemoteImage.kt
+++ b/components/android/coil3/src/main/kotlin/com/mirego/pilot/components/ui/coil3/PilotRemoteImage.kt
@@ -1,0 +1,62 @@
+package com.mirego.pilot.components.ui.coil3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import com.mirego.pilot.components.PilotRemoteImage
+import com.mirego.pilot.components.ui.pilotImageResourcePainter
+
+@Composable
+public fun PilotRemoteImage(
+    pilotRemoteImage: PilotRemoteImage,
+    modifier: Modifier = Modifier,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    allowHardware: Boolean = true,
+    asyncImageBuilder: ImageRequest.Builder.() -> Unit = {},
+) {
+    AsyncImage(
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(pilotRemoteImage.url)
+            .allowHardware(allowHardware)
+            .apply(asyncImageBuilder)
+            .build(),
+        contentDescription = pilotRemoteImage.contentDescription,
+        modifier = modifier,
+        transform = pilotRemoteImage.placeholder
+            ?.let { transformOf(pilotImageResourcePainter(it)) }
+            ?: AsyncImagePainter.DefaultTransform,
+        onState = onState,
+        contentScale = contentScale,
+        alignment = alignment,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality,
+    )
+}
+
+@Stable
+internal fun transformOf(placeholder: Painter): (AsyncImagePainter.State) -> AsyncImagePainter.State =
+    { state ->
+        when (state) {
+            is AsyncImagePainter.State.Loading -> if (state.painter == null) state.copy(painter = placeholder) else state
+            is AsyncImagePainter.State.Error -> if (state.painter == null) state.copy(painter = placeholder) else state
+            else -> state
+        }
+    }

--- a/components/android/coil3/src/main/kotlin/com/mirego/pilot/components/ui/coil3/PilotResizableRemoteImage.kt
+++ b/components/android/coil3/src/main/kotlin/com/mirego/pilot/components/ui/coil3/PilotResizableRemoteImage.kt
@@ -1,0 +1,66 @@
+package com.mirego.pilot.components.ui.coil3
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import com.mirego.pilot.components.PilotResizableRemoteImage
+import com.mirego.pilot.components.ui.pilotImageResourcePainter
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+public fun PilotResizableRemoteImage(
+    pilotRemoteImage: PilotResizableRemoteImage,
+    modifier: Modifier = Modifier,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    allowHardware: Boolean = true,
+    asyncImageBuilder: ImageRequest.Builder.() -> Unit = {},
+) {
+    BoxWithConstraints(modifier) {
+        with(LocalDensity.current) {
+            val url = remember(pilotRemoteImage, maxWidth, maxHeight) {
+                val maxWidthPx = maxWidth.takeIf { it != Dp.Infinity && it != Dp.Unspecified }?.roundToPx()
+                val maxHeightPx = maxHeight.takeIf { it != Dp.Infinity && it != Dp.Unspecified }?.roundToPx()
+                if (maxWidthPx == null && maxHeightPx == null) return@remember null
+                pilotRemoteImage.url(maxWidthPx, maxHeightPx)
+            }
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(url)
+                    .allowHardware(allowHardware)
+                    .apply(asyncImageBuilder)
+                    .build(),
+                contentDescription = pilotRemoteImage.contentDescription,
+                modifier = Modifier.matchParentSize(),
+                transform = pilotRemoteImage.placeholder
+                    ?.let { transformOf(pilotImageResourcePainter(it)) }
+                    ?: AsyncImagePainter.DefaultTransform,
+                onState = onState,
+                contentScale = contentScale,
+                alignment = alignment,
+                alpha = alpha,
+                colorFilter = colorFilter,
+                filterQuality = filterQuality,
+            )
+        }
+    }
+}

--- a/components/android/material3/api/components-material3.api
+++ b/components/android/material3/api/components-material3.api
@@ -1,16 +1,11 @@
 public final class com/mirego/pilot/components/ui/material3/ComposableSingletons$PilotAlertDialogKt {
 	public static final field INSTANCE Lcom/mirego/pilot/components/ui/material3/ComposableSingletons$PilotAlertDialogKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public static field lambda-4 Lkotlin/jvm/functions/Function4;
-	public static field lambda-5 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
-	public final fun getLambda-1$components_material3_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$components_material3_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$components_material3_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-4$components_material3_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-5$components_material3_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$1136491040$components_material3_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1308158669$components_material3_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda$142364561$components_material3_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$2086656925$components_material3_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$405589655$components_material3_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class com/mirego/pilot/components/ui/material3/PilotAlertDialogKt {

--- a/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotTextField.kt
+++ b/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotTextField.kt
@@ -70,7 +70,7 @@ public fun PilotTextField(
         keyboardActions = pilotTextField.mergeWith(keyboardActions),
         keyboardOptions = KeyboardOptions(
             capitalization = autoCapitalization.composeValue,
-            autoCorrect = autoCorrect,
+            autoCorrectEnabled = autoCorrect,
             keyboardType = keyboardType.composeValue,
             imeAction = keyboardReturnKeyType.composeValue,
         ),

--- a/components/common/api/components.api
+++ b/components/common/api/components.api
@@ -433,14 +433,11 @@ public final class com/mirego/pilot/components/ui/PilotButtonKt {
 
 public abstract interface class com/mirego/pilot/components/ui/PilotImageResourceProvider {
 	public abstract fun painterForResource (Lcom/mirego/pilot/components/PilotImageResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-	public abstract fun requirePainterForResource (Lcom/mirego/pilot/components/PilotImageResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
+	public fun requirePainterForResource (Lcom/mirego/pilot/components/PilotImageResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
 }
 
 public final class com/mirego/pilot/components/ui/PilotImageResourceProvider$DefaultImpls {
 	public static fun requirePainterForResource (Lcom/mirego/pilot/components/ui/PilotImageResourceProvider;Lcom/mirego/pilot/components/PilotImageResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-}
-
-public final class com/mirego/pilot/components/ui/PilotKeyboardActionsKt {
 }
 
 public final class com/mirego/pilot/components/ui/PilotLifecycleViewKt {
@@ -454,23 +451,11 @@ public final class com/mirego/pilot/components/ui/PilotResourceProviderKt {
 	public static final fun pilotImageResourcePainter (Lcom/mirego/pilot/components/PilotImageResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
 }
 
-public final class com/mirego/pilot/components/ui/PilotRichTextKt {
-}
-
 public abstract interface class com/mirego/pilot/components/ui/PilotTextStyleResourceProvider {
 	public abstract fun textStyleForResource (Lcom/mirego/pilot/components/PilotTextStyleResource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
 }
 
 public final class com/mirego/pilot/components/ui/extensions/SemanticsExtensionsKt {
 	public static final fun clearAndSetAccessibility (Landroidx/compose/ui/Modifier;Lcom/mirego/pilot/components/accessibility/PilotAccessibilityInfo;)Landroidx/compose/ui/Modifier;
-}
-
-public final class com/mirego/pilot/components/ui/type/PilotKeyboardAutoCapitalizationKt {
-}
-
-public final class com/mirego/pilot/components/ui/type/PilotKeyboardReturnKeyTypeKt {
-}
-
-public final class com/mirego/pilot/components/ui/type/PilotKeyboardTypeKt {
 }
 

--- a/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/PilotLifecycleView.kt
+++ b/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/PilotLifecycleView.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.mirego.pilot.components.lifecycle.PilotAppearanceLifecycle
 import com.mirego.pilot.components.lifecycle.onAppear
 

--- a/components/common/src/commonMain/kotlin/com/mirego/pilot/components/InternalPilotComponentsApi.kt
+++ b/components/common/src/commonMain/kotlin/com/mirego/pilot/components/InternalPilotComponentsApi.kt
@@ -4,4 +4,5 @@ package com.mirego.pilot.components
     level = RequiresOptIn.Level.ERROR,
     message = "This is internal API for Pilot Components. Do not use it directly.",
 )
+@Retention(AnnotationRetention.BINARY)
 public annotation class InternalPilotComponentsApi

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ android.enableJetifier=true
 android.useAndroidX=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
-version=0.3.8-SNAPSHOT
+version=0.4.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 coil3-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
+coil3-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil3" }
 
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,23 @@
 [versions]
-kotlin = "2.0.0"
-agp = "8.5.0"
-ktlint = "12.1.0"
-binary-compatibility = "0.13.2"
-androidx-compose-runtime = "1.6.8"
-androidx-compose-material3 = "1.2.1"
-androidx-lifecycle = "2.8.2"
-androidx-navigation = "2.7.7"
-androidx-activity-compose = "1.9.0"
-kotlinx-coroutines = "1.8.1"
+kotlin = "2.2.0"
+agp = "8.11.1"
+ktlint = "13.0.0"
+binary-compatibility = "0.18.1"
+androidx-compose-runtime = "1.8.3"
+androidx-compose-material3 = "1.3.2"
+androidx-lifecycle = "2.9.2"
+androidx-navigation = "2.9.2"
+androidx-activity-compose = "1.10.1"
+kotlinx-coroutines = "1.10.2"
 mirego-publish = "1.5"
-coil = "2.5.0"
-dokka = "1.9.20"
+coil = "2.7.0"
+coil3 = "3.3.0"
+dokka = "2.0.0"
 assertk = "0.28.1"
 
 [libraries]
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk"  }
@@ -33,8 +33,8 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-navigation-runtime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidx-navigation" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 
-coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+coil3-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
 
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(
     ":viewmodel",
     ":components",
     ":components-coil",
+    ":components-coil3",
     ":components-material3",
 )
 
@@ -29,6 +30,7 @@ project(":navigation").projectDir = File("navigation/common")
 project(":viewmodel").projectDir = File("viewmodel/common")
 project(":components").projectDir = File("components/common")
 project(":components-coil").projectDir = File("components/android/coil")
+project(":components-coil3").projectDir = File("components/android/coil3")
 project(":components-material3").projectDir = File("components/android/material3")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
In order to keep the compatibility with the older version of Coil, we add a new module for the latest version. This way we could deprecate version 2 eventually while keeping the new module.