### PR TITLE
Features/add enabled controls

### DIFF
--- a/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotPicker.kt
+++ b/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotPicker.kt
@@ -30,10 +30,12 @@ public fun <LABEL : Any, ITEM : Any> PilotPicker(
     labelView: @Composable (label: LABEL) -> Unit,
     item: @Composable (item: ITEM) -> Unit,
 ) {
+    val isEnabled by pilotPicker.isEnabled.collectAsState()
     Box {
         Box(
             modifier = modifier
                 .clickable(
+                    enabled = isEnabled,
                     onClick = { onExpandedChange(!expanded) },
                     role = Role.DropdownList,
                 ),

--- a/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotTextField.kt
+++ b/components/android/material3/src/main/kotlin/com/mirego/pilot/components/ui/material3/PilotTextField.kt
@@ -50,6 +50,7 @@ public fun PilotTextField(
 ) {
     val textValue by pilotTextField.text.collectAsState()
     val placeHolder by pilotTextField.placeholder.collectAsState()
+    val isEnabledFlow by pilotTextField.isEnabled.collectAsState()
     val autoCapitalization by pilotTextField.autoCapitalization.collectAsState()
     val autoCorrect by pilotTextField.autoCorrect.collectAsState()
     val keyboardType by pilotTextField.keyboardType.collectAsState()
@@ -100,7 +101,7 @@ public fun PilotTextField(
         interactionSource = interactionSource,
         shape = shape,
         colors = colors,
-        enabled = enabled,
+        enabled = enabled && isEnabledFlow,
         readOnly = readOnly,
         singleLine = singleLine,
     )

--- a/components/common/api/components.api
+++ b/components/common/api/components.api
@@ -154,13 +154,14 @@ public final class com/mirego/pilot/components/PilotRichTextSpan$Style : com/mir
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/mirego/pilot/components/PilotSwitch {
+public class com/mirego/pilot/components/PilotSwitch {
 	public static final field $stable I
-	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlinx/coroutines/flow/StateFlow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getLabel ()Ljava/lang/Object;
-	public final fun getOnCheckedChange ()Lkotlin/jvm/functions/Function1;
-	public final fun isOn ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;Ljava/lang/Object;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/flow/StateFlow;Ljava/lang/Object;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getLabel ()Ljava/lang/Object;
+	public fun getOnCheckedChange ()Lkotlin/jvm/functions/Function1;
+	public fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun isOn ()Lkotlinx/coroutines/flow/StateFlow;
 }
 
 public class com/mirego/pilot/components/PilotTextField {

--- a/components/common/api/components.api
+++ b/components/common/api/components.api
@@ -15,12 +15,14 @@ public abstract interface class com/mirego/pilot/components/PilotImageResource {
 	public abstract fun getName ()Ljava/lang/String;
 }
 
-public final class com/mirego/pilot/components/PilotPicker {
+public class com/mirego/pilot/components/PilotPicker {
 	public static final field $stable I
-	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;)V
-	public final fun getItems ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getLabel ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getOnSelectedIndex ()Lkotlin/jvm/functions/Function1;
+	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getItems ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getLabel ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getOnSelectedIndex ()Lkotlin/jvm/functions/Function1;
+	public fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
 }
 
 public final class com/mirego/pilot/components/PilotRemoteImage {
@@ -166,20 +168,21 @@ public class com/mirego/pilot/components/PilotSwitch {
 
 public class com/mirego/pilot/components/PilotTextField {
 	public static final field $stable I
-	public fun <init> (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAutoCapitalization ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getAutoCorrect ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getContentType ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getFormatText ()Lkotlin/jvm/functions/Function1;
-	public final fun getKeyboardReturnKeyType ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getKeyboardType ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getOnReturnKeyTap ()Lkotlin/jvm/functions/Function0;
-	public final fun getPlaceholder ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun <init> (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/flow/MutableStateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAutoCapitalization ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getAutoCorrect ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getContentType ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getFormatText ()Lkotlin/jvm/functions/Function1;
+	public fun getKeyboardReturnKeyType ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getKeyboardType ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getOnReturnKeyTap ()Lkotlin/jvm/functions/Function0;
+	public fun getPlaceholder ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getText ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getTextObfuscationMode ()Lkotlinx/coroutines/flow/StateFlow;
-	public final fun getTransformText ()Lkotlin/jvm/functions/Function1;
-	public final fun getUnformatText ()Lkotlin/jvm/functions/Function1;
+	public fun getTextObfuscationMode ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getTransformText ()Lkotlin/jvm/functions/Function1;
+	public fun getUnformatText ()Lkotlin/jvm/functions/Function1;
+	public fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun onValueChange (Ljava/lang/String;)V
 }
 

--- a/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotPicker.kt
+++ b/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotPicker.kt
@@ -1,9 +1,11 @@
 package com.mirego.pilot.components
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-public class PilotPicker<LABEL : Any, ITEM : Any>(
-    public val label: StateFlow<LABEL>,
-    public val items: StateFlow<List<ITEM>>,
-    public val onSelectedIndex: (Int) -> Unit,
+public open class PilotPicker<LABEL : Any, ITEM : Any>(
+    public open val label: StateFlow<LABEL>,
+    public open val items: StateFlow<List<ITEM>>,
+    public open val isEnabled: StateFlow<Boolean> = MutableStateFlow(true),
+    public open val onSelectedIndex: (Int) -> Unit,
 )

--- a/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotSwitch.kt
+++ b/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotSwitch.kt
@@ -1,9 +1,11 @@
 package com.mirego.pilot.components
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-public class PilotSwitch<T : Any>(
-    public val isOn: StateFlow<Boolean>,
-    public val label: T,
-    public val onCheckedChange: (Boolean) -> Unit = {},
+public open class PilotSwitch<T : Any>(
+    public open val isOn: StateFlow<Boolean>,
+    public open val label: T,
+    public open val isEnabled: StateFlow<Boolean> = MutableStateFlow(true),
+    public open val onCheckedChange: (Boolean) -> Unit = {},
 )

--- a/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotTextField.kt
+++ b/components/common/src/commonMain/kotlin/com/mirego/pilot/components/PilotTextField.kt
@@ -10,17 +10,18 @@ import kotlinx.coroutines.flow.StateFlow
 
 public open class PilotTextField(
     private val textFlow: MutableStateFlow<String>,
-    public val placeholder: StateFlow<String>,
-    public val keyboardType: StateFlow<PilotKeyboardType> = MutableStateFlow(PilotKeyboardType.Default),
-    public val keyboardReturnKeyType: StateFlow<PilotKeyboardReturnKeyType> = MutableStateFlow(PilotKeyboardReturnKeyType.Default),
-    public val contentType: StateFlow<PilotTextContentType> = MutableStateFlow(PilotTextContentType.NotSet),
-    public val textObfuscationMode: StateFlow<PilotTextObfuscationMode> = MutableStateFlow(PilotTextObfuscationMode.Visible),
-    public val autoCorrect: StateFlow<Boolean> = MutableStateFlow(true),
-    public val autoCapitalization: StateFlow<PilotKeyboardAutoCapitalization> = MutableStateFlow(PilotKeyboardAutoCapitalization.Sentences),
-    public val onReturnKeyTap: () -> Unit = {},
-    public val formatText: (text: String) -> String = { it },
-    public val unformatText: (text: String) -> String = { it },
-    public val transformText: (text: String) -> String = { it },
+    public open val placeholder: StateFlow<String>,
+    public open val isEnabled: StateFlow<Boolean> = MutableStateFlow(true),
+    public open val keyboardType: StateFlow<PilotKeyboardType> = MutableStateFlow(PilotKeyboardType.Default),
+    public open val keyboardReturnKeyType: StateFlow<PilotKeyboardReturnKeyType> = MutableStateFlow(PilotKeyboardReturnKeyType.Default),
+    public open val contentType: StateFlow<PilotTextContentType> = MutableStateFlow(PilotTextContentType.NotSet),
+    public open val textObfuscationMode: StateFlow<PilotTextObfuscationMode> = MutableStateFlow(PilotTextObfuscationMode.Visible),
+    public open val autoCorrect: StateFlow<Boolean> = MutableStateFlow(true),
+    public open val autoCapitalization: StateFlow<PilotKeyboardAutoCapitalization> = MutableStateFlow(PilotKeyboardAutoCapitalization.Sentences),
+    public open val onReturnKeyTap: () -> Unit = {},
+    public open val formatText: (text: String) -> String = { it },
+    public open val unformatText: (text: String) -> String = { it },
+    public open val transformText: (text: String) -> String = { it },
 ) {
 
     public val text: StateFlow<String> = textFlow

--- a/components/ios/base/PilotPickerView.swift
+++ b/components/ios/base/PilotPickerView.swift
@@ -9,6 +9,7 @@ public struct PilotPickerView<Label, LabelView, Item, ItemView>: View where Labe
 
     @ObservedObject private var label: StateObservable<Label>
     @ObservedObject private var items: StateObservable<[Item]>
+    @ObservedObject private var isEnabled: StateObservable<KotlinBoolean>
 
     public init(
         _ picker: PilotPicker<Label, Item>,
@@ -21,6 +22,7 @@ public struct PilotPickerView<Label, LabelView, Item, ItemView>: View where Labe
 
         _label = ObservedObject(wrappedValue: StateObservable(picker.label))
         _items = ObservedObject(wrappedValue: StateObservable(picker.items))
+        _isEnabled = ObservedObject(wrappedValue: StateObservable(picker.isEnabled))
     }
 
     public var body: some View {
@@ -35,5 +37,6 @@ public struct PilotPickerView<Label, LabelView, Item, ItemView>: View where Labe
         } label: {
             labelBuilder(label.value)
         }
+        .disabled(!isEnabled.value.boolValue)
     }
 }

--- a/components/ios/base/PilotSwitchView.swift
+++ b/components/ios/base/PilotSwitchView.swift
@@ -6,11 +6,13 @@ public struct PilotSwitchView<Content, Label>: View where Content: AnyObject, La
     private let labelBuilder: (Content) -> Label
 
     @ObservedObject private var isOn: StateObservable<KotlinBoolean>
+    @ObservedObject private var isEnabled: StateObservable<KotlinBoolean>
 
     public init(_ pilotSwitch: PilotSwitch<Content>, labelBuilder: @escaping (Content) -> Label) {
         self.pilotSwitch = pilotSwitch
         self.labelBuilder = labelBuilder
         _isOn = ObservedObject(wrappedValue: StateObservable(pilotSwitch.isOn))
+        _isEnabled = ObservedObject(wrappedValue: StateObservable(pilotSwitch.isEnabled))
     }
 
     public var body: some View {
@@ -25,5 +27,6 @@ public struct PilotSwitchView<Content, Label>: View where Content: AnyObject, La
         ) {
             labelBuilder(pilotSwitch.label)
         }
+        .disabled(!isEnabled.value.boolValue)
     }
 }

--- a/components/ios/base/PilotTextFieldView.swift
+++ b/components/ios/base/PilotTextFieldView.swift
@@ -7,6 +7,7 @@ public struct PilotTextFieldView<Label>: View where Label: View {
 
     @ObservedObject private var text: StateObservable<String>
     @ObservedObject private var placeholder: StateObservable<String>
+    @ObservedObject private var isEnabled: StateObservable<KotlinBoolean>
     @ObservedObject private var keyboardType: StateObservable<PilotKeyboardType>
     @ObservedObject private var keyboardReturnKeyType: StateObservable<PilotKeyboardReturnKeyType>
     @ObservedObject private var contentType: StateObservable<PilotTextContentType>
@@ -28,6 +29,7 @@ public struct PilotTextFieldView<Label>: View where Label: View {
 
         _text = ObservedObject(wrappedValue: StateObservable(pilotTextField.text))
         _placeholder = ObservedObject(wrappedValue: StateObservable(pilotTextField.placeholder))
+        _isEnabled = ObservedObject(wrappedValue: StateObservable(pilotTextField.isEnabled))
         _keyboardType = ObservedObject(wrappedValue: StateObservable(pilotTextField.keyboardType))
         _keyboardReturnKeyType = ObservedObject(wrappedValue: StateObservable(pilotTextField.keyboardReturnKeyType))
         _contentType = ObservedObject(wrappedValue: StateObservable(pilotTextField.contentType))
@@ -50,6 +52,7 @@ public struct PilotTextFieldView<Label>: View where Label: View {
             .textContentType(contentType.value.uiTextContentType)
             #endif
             .disableAutocorrection(!autoCorrect.value.boolValue)
+            .disabled(!isEnabled.value.boolValue)
             .textFieldStyle(ExtendedTapAreaTextFieldStyle())
             .onChange(of: text.value) { newValue in
                 textFieldText = pilotTextField.formatText(newValue)


### PR DESCRIPTION
# Description

- Add a `isEnabled` flow to all Pilot controls : `PilotPicker`, `PilotSwitch` and `PilotTextField`. We follow the same behavior used by `PilotButton` to be able to set the control and disabled from the common.
- We also make these component `open` to make it easier to extend their functionalities. Again, same behavior as PilotButton
