### PR TITLE
Have only one text field visible at the time

### DIFF
--- a/components/ios/base/PilotTextFieldView.swift
+++ b/components/ios/base/PilotTextFieldView.swift
@@ -1,7 +1,7 @@
 import Shared
 import SwiftUI
 
-public struct PilotTextFieldView<Label>: View where Label: View {
+public struct PilotTextFieldView<Label: View>: View {
     private let pilotTextField: PilotTextField
     private let placeholderBuilder: (String) -> Label
 
@@ -16,12 +16,6 @@ public struct PilotTextFieldView<Label>: View where Label: View {
     @ObservedObject private var autoCapitalization: StateObservable<PilotKeyboardAutoCapitalization>
 
     @State private var textFieldText: String
-    @FocusState private var focusedField: FieldType?
-
-    private enum FieldType {
-        case secure
-        case plain
-    }
 
     public init(_ pilotTextField: PilotTextField, placeholderBuilder: @escaping (String) -> Label) {
         self.pilotTextField = pilotTextField
@@ -46,11 +40,11 @@ public struct PilotTextFieldView<Label>: View where Label: View {
                 pilotTextField.onReturnKeyTap()
             }
             .submitLabel(keyboardReturnKeyType.value.submitLabel)
-            #if canImport(UIKit)
+        #if canImport(UIKit)
             .keyboardType(keyboardType.value.uiKeyboardType)
             .autocapitalization(autoCapitalization.value.uiTextAutocapitalizationType)
             .textContentType(contentType.value.uiTextContentType)
-            #endif
+        #endif
             .disableAutocorrection(!autoCorrect.value.boolValue)
             .disabled(!isEnabled.value.boolValue)
             .textFieldStyle(ExtendedTapAreaTextFieldStyle())
@@ -62,29 +56,19 @@ public struct PilotTextFieldView<Label>: View where Label: View {
                 textFieldText = pilotTextField.formatText(pilotTextField.transformText(unformattedText))
                 pilotTextField.onValueChange(text: unformattedText)
             }
-            .onChange(of: textObfuscationMode.value) { newValue in
-                if focusedField != nil {
-                    withAnimation(nil) {
-                        focusedField = newValue == .hidden ? .secure : .plain
-                    }
-                }
-            }
     }
 
-    @ViewBuilder
     private var baseTextField: some View {
-        ZStack {
-            SecureField(text: $textFieldText) {
-                placeholderBuilder(placeholder.value)
+        Group {
+            if textObfuscationMode.value == .hidden {
+                SecureField(text: $textFieldText) {
+                    placeholderBuilder(placeholder.value)
+                }
+            } else {
+                TextField(text: $textFieldText) {
+                    placeholderBuilder(placeholder.value)
+                }
             }
-            .opacity(textObfuscationMode.value == .hidden ? 1 : 0)
-            .focused($focusedField, equals: .secure)
-
-            TextField(text: $textFieldText) {
-                placeholderBuilder(placeholder.value)
-            }
-            .opacity(textObfuscationMode.value == .visible ? 1 : 0)
-            .focused($focusedField, equals: .plain)
         }
         .transaction { transaction in
             transaction.animation = nil


### PR DESCRIPTION
# Description

This PR (https://github.com/mirego/viewmodel-pilot/pull/35) introduced `PilotTextObfuscationMode` to display a `SecureField` on iOS for hidden fields. However, having two textfield at once, even tho one was hidden introduced two problems:
1. We could not correctly read the focused state of the textfield from outside the view.
2. Having two textfield at once, even tho one was hidden conflicted with swiftui auto focus of the next field when pressing tab on a textfield on a view with multiple textfield

## Solution

To fix this, we only present one field at a time based on the `textObfuscationMode`. Transition between the two are not impacted.

### Notes

We lose focus of the textfield if we are to change the `textObfuscationMode`, however, to prevent conflicting with external focused state, this should be handled by the client