### PR TITLE
Fix iOS `StateObservable` data race when updating cached state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming
 
+### Fixed
+- iOS `StateObservable` no longer races on its cached state: the flow/state-flow collection now mutates `lastState` on the main actor instead of the background collection context, preventing a crash (`objc_opt_isKindOfClass` via SKIE `onEnum`) when the value is read during SwiftUI body evaluation
+
 ### Updates
 
 ### Breaking Changes

--- a/viewmodel/ios/NullableStateObservable.swift
+++ b/viewmodel/ios/NullableStateObservable.swift
@@ -32,18 +32,7 @@ public class NullableStateObservable<State>: ObservableObject {
 
         task = Task { [weak self] in
             for await newState in stateFlow.dropFirst() {
-                if let animation = self?.animation?(self?.lastState, newState) {
-                    DispatchQueue.main.async {
-                        withAnimation(animation) {
-                            self?.objectWillChange.send()
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self?.objectWillChange.send()
-                    }
-                }
-                self?.lastState = newState
+                await self?.apply(newState)
             }
         }
     }
@@ -55,20 +44,21 @@ public class NullableStateObservable<State>: ObservableObject {
 
         task = Task { [weak self] in
             for await newState in flow {
-                if let animation = self?.animation?(self?.lastState, newState) {
-                    DispatchQueue.main.async {
-                        withAnimation(animation) {
-                            self?.objectWillChange.send()
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self?.objectWillChange.send()
-                    }
-                }
-                self?.lastState = newState
+                await self?.apply(newState)
             }
         }
+    }
+
+    @MainActor
+    private func apply(_ newState: State?) {
+        if let animation = animation?(lastState, newState) {
+            withAnimation(animation) {
+                objectWillChange.send()
+            }
+        } else {
+            objectWillChange.send()
+        }
+        lastState = newState
     }
 
     deinit {

--- a/viewmodel/ios/StateObservable.swift
+++ b/viewmodel/ios/StateObservable.swift
@@ -32,18 +32,7 @@ public class StateObservable<State>: ObservableObject {
 
         task = Task { [weak self] in
             for await newState in stateFlow.dropFirst() {
-                if let lastState = self?.lastState, let animation = self?.animation?(lastState, newState) {
-                    DispatchQueue.main.async {
-                        withAnimation(animation) {
-                            self?.objectWillChange.send()
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self?.objectWillChange.send()
-                    }
-                }
-                self?.lastState = newState
+                await self?.apply(newState)
             }
         }
     }
@@ -55,20 +44,21 @@ public class StateObservable<State>: ObservableObject {
 
         task = Task { [weak self] in
             for await newState in flow {
-                if let lastState = self?.lastState, let animation = self?.animation?(lastState, newState) {
-                    DispatchQueue.main.async {
-                        withAnimation(animation) {
-                            self?.objectWillChange.send()
-                        }
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        self?.objectWillChange.send()
-                    }
-                }
-                self?.lastState = newState
+                await self?.apply(newState)
             }
         }
+    }
+
+    @MainActor
+    private func apply(_ newState: State) {
+        if let animation = animation?(lastState, newState) {
+            withAnimation(animation) {
+                objectWillChange.send()
+            }
+        } else {
+            objectWillChange.send()
+        }
+        lastState = newState
     }
 
     deinit {


### PR DESCRIPTION
# Problem
  
  We're seeing a recurring main-thread crash in TSN/RDS production.

```
  Crashed: com.apple.main-thread
  0  libobjc.A.dylib   objc_opt_isKindOfClass + 48
  1  libswiftCore      swift_dynamicCastObjCClassImpl
  2  Shared            specialized onEnum<A>(of:)            (GameStatusBannerContent.swift:19)
  4  TSN               GameStatusBannerView.contentView.getter (GameStatusBannerView.swift:31)
  5  TSN               GameStatusBannerView.body.getter      (GameStatusBannerView.swift:19)
     … SwiftUI ViewBodyAccessor.updateBody → AttributeGraph → layout
```

  The crash happens on the main thread while SwiftUI is evaluating a view's body and SKIE's generated onEnum(of:) performs a runtime class check (objc_opt_isKindOfClass) on the observed state enum. The class check faults because the reference it reads is invalid.

  The root cause is a data race in StateObservable / NullableStateObservable. These types collect a Kotlin/KMP Flow/StateFlow on a background context and, on each emission, write their cached lastState property synchronously on that background thread. SwiftUI reads the same lastState on the main thread during body evaluation. When a write and a read overlap, the main thread can observe a torn/half-published value  and the subsequent dynamic cast in onEnum operates on garbage,crashing the app.

  The notification path made this worse: objectWillChange.send() was dispatched to the main queue fire-and-forget while lastState mutated immediately on the background thread, so the published change notification and the cached value it represented could momentarily disagree.

# Solution
  
 All mutation of lastState (and the matching objectWillChange notification) is now funneled through a single @MainActor method that the collection loop awaits, instead of being done inline on the background collection context.

  The reasoning: the value is consumed on the main actor (SwiftUI rendering reads it), so it must also be produced on the main actor. Pinning the read of the previous state, the change notification, and the write of the new state to the main actor means they can never overlap with SwiftUI's reads of the same property. The race is removed at its source:  there is now only one actor touching lastState, so the reference SKIE casts is always a valid, fully-published object and onEnum's isKindOfClass can no longer hit corrupt memory.

  As a side benefit this also removes the previous manual DispatchQueue.main.async hops, since the whole update already runs on the main actor. The same change is applied to both StateObservable and NullableStateObservable.