### PR TITLE
Add Decimal and NumberPunctuation keyboard types

### DIFF
--- a/components/common/api/components.api
+++ b/components/common/api/components.api
@@ -373,10 +373,12 @@ public final class com/mirego/pilot/components/type/PilotKeyboardReturnKeyType :
 
 public final class com/mirego/pilot/components/type/PilotKeyboardType : java/lang/Enum {
 	public static final field Ascii Lcom/mirego/pilot/components/type/PilotKeyboardType;
+	public static final field Decimal Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field Default Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field Email Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field Number Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field NumberPassword Lcom/mirego/pilot/components/type/PilotKeyboardType;
+	public static final field NumberPunctuation Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field Password Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field Phone Lcom/mirego/pilot/components/type/PilotKeyboardType;
 	public static final field URL Lcom/mirego/pilot/components/type/PilotKeyboardType;

--- a/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/type/PilotKeyboardType.kt
+++ b/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/type/PilotKeyboardType.kt
@@ -16,5 +16,5 @@ public val PilotKeyboardType.composeValue: KeyboardType
         PilotKeyboardType.Phone -> KeyboardType.Phone
         PilotKeyboardType.URL -> KeyboardType.Uri
         PilotKeyboardType.Decimal -> KeyboardType.Decimal
-        PilotKeyboardType.NumberPunctuation -> KeyboardType.Phone
+        PilotKeyboardType.NumberPunctuation -> KeyboardType.Ascii // TODO Use DecimalSigned when Compose 1.12.0 hits stable
     }

--- a/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/type/PilotKeyboardType.kt
+++ b/components/common/src/androidMain/kotlin/com/mirego/pilot/components/ui/type/PilotKeyboardType.kt
@@ -15,4 +15,6 @@ public val PilotKeyboardType.composeValue: KeyboardType
         PilotKeyboardType.NumberPassword -> KeyboardType.NumberPassword
         PilotKeyboardType.Phone -> KeyboardType.Phone
         PilotKeyboardType.URL -> KeyboardType.Uri
+        PilotKeyboardType.Decimal -> KeyboardType.Decimal
+        PilotKeyboardType.NumberPunctuation -> KeyboardType.Phone
     }

--- a/components/common/src/commonMain/kotlin/com/mirego/pilot/components/type/PilotKeyboardType.kt
+++ b/components/common/src/commonMain/kotlin/com/mirego/pilot/components/type/PilotKeyboardType.kt
@@ -9,4 +9,6 @@ public enum class PilotKeyboardType {
     NumberPassword,
     Phone,
     URL,
+    Decimal,
+    NumberPunctuation,
 }

--- a/components/ios/base/Types/PilotKeyboardType.swift
+++ b/components/ios/base/Types/PilotKeyboardType.swift
@@ -10,6 +10,8 @@ extension PilotKeyboardType {
             return .asciiCapable
         case .number:
             return .numberPad
+        case .decimal:
+            return .decimalPad
         case .email:
             return .emailAddress
         case .password:
@@ -20,6 +22,8 @@ extension PilotKeyboardType {
             return .phonePad
         case .url:
             return .URL
+        case .numberPunctuation:
+            return .numbersAndPunctuation
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Decimal` keyboard type — maps to `KeyboardType.Decimal` (Compose) and `.decimalPad` (iOS)
- Adds `NumberPunctuation` keyboard type — maps to `KeyboardType.Phone` (Compose, closest match for numbers + symbols) and `.numbersAndPunctuation` (iOS)